### PR TITLE
Wording tweaks

### DIFF
--- a/src/page1.html
+++ b/src/page1.html
@@ -11,7 +11,7 @@
 			<div class="section-header">
 				<div>Sound Services</div>
 			</div>
-			<div>Select both an Input option and an Output option to best fit your event type and size.
+			<div>Select both an Inputs option and a Speakers option to best fit your event type and size.
 				Then, choose any Add-ons for more speakers or wireless microhpones.
 			</div>
 		</div>
@@ -84,8 +84,8 @@
 								<div>$120</div>
 							</div>
 							<div class="option-description">A pair of speakers for 
-							an event in a large space with more people. Great 
-							for concerts, bands, and stage shows. 
+							an event in a larger space with more people. Great
+							for dances, concerts, bands, and stage shows.
 							</div>
 							<img class="option-img" src="assets/speakers_large.jpg">
 						</li>
@@ -112,7 +112,7 @@
 								<div>Subwoofers</div>
 								<div>$50</div>
 							</div>
-							<div class="option-description">Subwoofers add more bass. Great for concerts, bands, or just playing music.</div>
+							<div class="option-description">Subwoofers add more bass. Great for dances, bands, or just playing music.</div>
 						</li>
 						<li class="list-group-item option">
 							<div class="option-head">


### PR DESCRIPTION
- Change "Output" to "Speakers" in page 1 header; resolves #1
- Add dances to "great for" for large speakers and subwoofers; resolves #2
- Remove concerts from "great for" for subwoofers because bands are already mentioned separately and other kinds of concerts, e.g. concert band concerts, don't need subwoofers.